### PR TITLE
🔧 chore: update favicon link to use site.baseurl

### DIFF
--- a/docs/pages/_includes/head-custom.html
+++ b/docs/pages/_includes/head-custom.html
@@ -2,4 +2,8 @@
 {% include head-custom-google-analytics.html %}
 
 <!-- Setup favicon -->
-<link rel="icon" href="./assets/icons/favicon.svg" type="image/svg+xml" />
+<link
+  rel="icon"
+  href="{{ site.baseurl }}/assets/icons/favicon.svg"
+  type="image/svg+xml"
+/>


### PR DESCRIPTION
## 🎯 Purpose

Update the favicon link to utilize the `site.baseurl` for better path resolution.

## 💡 Notes

No breaking changes introduced.