### PR TITLE
🔧 chore: add 'tofile' to recognized words list

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -174,6 +174,7 @@ words:
   - thirdparty
   - timespan
   - tmpl
+  - tofile
   - toml
   - tomlkit
   - tspan


### PR DESCRIPTION
## 🎯 Purpose

Add 'tofile' to the list of recognized words for cspell to improve spell checking accuracy.

## 💡 Notes

No breaking changes introduced.